### PR TITLE
devtools(brzip): add tool for inspecting worlds/prefabs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +156,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "brzip"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "brdb",
+ "clap",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +188,52 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "clap"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "constant_time_eq"
@@ -243,12 +356,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "home"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -261,6 +380,12 @@ dependencies = [
  "hashbrown",
  "serde",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -390,6 +515,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "parking_lot"
@@ -644,6 +775,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,7 +798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a984c8d058c627faaf5e8e2ed493fa3c51771889196de1016cf9c1c6e90d750"
 dependencies = [
  "home",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -701,6 +838,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -745,8 +888,14 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -755,6 +904,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/brdb"]
+members = ["crates/brdb", "crates/brzip"]
 resolver = "3"
 
 [workspace.dependencies]

--- a/crates/brzip/Cargo.toml
+++ b/crates/brzip/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "brzip"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+brdb = { path = "../brdb", features = ["brdb", "brz"] }
+clap = { version = "4.5.23", features = ["derive"] }
+anyhow = "1.0.95"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"

--- a/crates/brzip/README.md
+++ b/crates/brzip/README.md
@@ -1,0 +1,45 @@
+# brzip
+
+`brzip` is a command-line tool for unpacking Brickadia save files (`.brdb`) and prefab files (`.brz`). It allows you to inspect the internal structure of these files and optionally convert their binary data schemas and contents into readable JSON format.
+
+## Usage
+
+```bash
+brzip <input_file> [output_directory] [options]
+```
+
+### Arguments
+
+*   `<input_file>`: The path to the `.brdb` or `.brz` file you want to unpack.
+*   `[output_directory]`: (Optional) The directory where the unpacked contents should be saved. If not provided, a directory with the same name as the input file (excluding extension) will be created in the input file's directory.
+
+### Options
+
+*   `--json`: Enables automatic conversion of `.schema` and `.mps` (MessagePack serialized) files to JSON. The JSON files will be created alongside their binary counterparts with `.json` appended to the filename (e.g., `GlobalData.mps.json`).
+
+## Examples
+
+**Unpack a save file:**
+
+```bash
+cargo run -p brzip -- MyWorld.brdb
+```
+
+**Unpack a prefab to a specific directory:**
+
+```bash
+cargo run -p brzip -- MyPrefab.brz ./unpacked_prefab
+```
+
+**Unpack and convert data to JSON:**
+
+```bash
+cargo run -p brzip -- MyWorld.brdb --json
+```
+
+## JSON Output
+
+When the `--json` flag is used:
+
+*   `.schema` files are converted to `.schema.json`, showing the enums and structs defined in the schema.
+*   `.mps` files are converted to `.mps.json`, showing the actual data values deserialized according to their corresponding schema.

--- a/crates/brzip/src/main.rs
+++ b/crates/brzip/src/main.rs
@@ -1,0 +1,283 @@
+use std::path::{Path, PathBuf};
+use clap::Parser;
+use anyhow::{Context, Result, bail};
+use brdb::{
+    Brdb, Brz, IntoReader,
+    pending::BrPendingFs,
+    BrReader, BrFsReader,
+    schema::{BrdbSchema, BrdbValue, ReadBrdbSchema, BrdbSchemaGlobalData},
+    schemas,
+};
+use std::sync::Arc;
+use serde_json::{json, Value};
+
+#[derive(Parser)]
+#[command(name = "brzip")]
+#[command(about = "A tool to unpack .brdb and .brz files")]
+struct Cli {
+    /// The input file to unpack
+    input: PathBuf,
+
+    /// The output directory (optional, defaults to input filename without extension)
+    output: Option<PathBuf>,
+
+    /// Convert .schema and .mps files to JSON
+    #[arg(long)]
+    json: bool,
+}
+
+fn main() -> Result<()> {
+    let args = Cli::parse();
+
+    let input_path = args.input.clone();
+    if !input_path.exists() {
+        bail!("Input file does not exist: {}", input_path.display());
+    }
+
+    let output_path = match args.output.clone() {
+        Some(p) => p,
+        None => {
+            let file_stem = input_path.file_stem().context("Invalid input filename")?;
+            let mut p = input_path.parent().unwrap_or(Path::new("")).to_path_buf();
+            p.push(file_stem);
+            p
+        }
+    };
+
+    println!("Unpacking {} to {}", input_path.display(), output_path.display());
+
+    let extension = input_path.extension().and_then(|s| s.to_str()).unwrap_or("");
+
+    if extension.eq_ignore_ascii_case("brdb") {
+        let db = Brdb::open(&input_path).context("Failed to open .brdb file")?;
+        let reader = BrReader::new(db);
+        let pending_fs = reader.to_pending().context("Failed to read filesystem from .brdb")?;
+        unpack_pending_fs(&reader, &pending_fs, &output_path, args.json).context("Failed to unpack filesystem")?;
+    } else if extension.eq_ignore_ascii_case("brz") {
+        let brz = Brz::open(&input_path).context("Failed to open .brz file")?;
+        let reader = brz.into_reader();
+        let pending_fs = reader.to_pending().context("Failed to convert .brz to pending fs")?;
+        unpack_pending_fs(&reader, &pending_fs, &output_path, args.json).context("Failed to unpack filesystem")?;
+    } else {
+         bail!("Unknown file extension: {}. Supported: .brdb, .brz", extension);
+    };
+
+    println!("Done.");
+
+    Ok(())
+}
+
+fn unpack_pending_fs<T: BrFsReader>(reader: &BrReader<T>, fs: &BrPendingFs, path: &Path, convert_json: bool) -> Result<()> {
+    unpack_recursive(reader, fs, path, PathBuf::new(), convert_json)
+}
+
+fn unpack_recursive<T: BrFsReader>(reader: &BrReader<T>, fs: &BrPendingFs, output_root: &Path, rel_path: PathBuf, convert_json: bool) -> Result<()> {
+    use std::fs;
+
+    match fs {
+        BrPendingFs::Root(children) => {
+            fs::create_dir_all(output_root.join(&rel_path))?;
+            for (name, child) in children {
+                unpack_recursive(reader, child, output_root, rel_path.join(name), convert_json)?;
+            }
+        }
+        BrPendingFs::Folder(Some(children)) => {
+            fs::create_dir_all(output_root.join(&rel_path))?;
+            for (name, child) in children {
+                unpack_recursive(reader, child, output_root, rel_path.join(name), convert_json)?;
+            }
+        }
+        BrPendingFs::Folder(None) => {
+             fs::create_dir_all(output_root.join(&rel_path))?;
+        }
+        BrPendingFs::File(Some(content)) => {
+            let final_path = output_root.join(&rel_path);
+            if let Some(parent) = final_path.parent() {
+                 fs::create_dir_all(parent)?;
+            }
+            fs::write(&final_path, content)?;
+
+            if convert_json {
+                if let Err(e) = convert_to_json(reader, &rel_path, content, &final_path) {
+                    eprintln!("Warning: Failed to convert {} to JSON: {}", rel_path.display(), e);
+                }
+            }
+        }
+        BrPendingFs::File(None) => {
+        }
+    }
+    Ok(())
+}
+
+fn convert_to_json<T: BrFsReader>(reader: &BrReader<T>, rel_path: &Path, content: &[u8], output_path: &Path) -> Result<()> {
+    let ext = rel_path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    let path_str = rel_path.to_string_lossy();
+
+
+    let mut cursor = content;
+
+    if ext == "schema" {
+
+        let global_data = match reader.global_data() {
+            Ok(gd) => gd,
+            Err(_) => {
+                Arc::new(BrdbSchemaGlobalData::default())
+            }
+        };
+
+        let schema = match cursor.read_brdb_schema_with_data(global_data) {
+            Ok(s) => s,
+            Err(_) => {
+
+                 let mut cursor2 = content;
+                 cursor2.read_brdb_schema()?
+            }
+        };
+        
+        let json_val = schema_to_json(&schema);
+        let mut json_path = output_path.to_path_buf();
+        json_path.set_extension("schema.json");
+        let file = std::fs::File::create(json_path)?;
+        serde_json::to_writer_pretty(file, &json_val)?;
+
+    } else if ext == "mps" {
+
+        let (schema_path, type_name) = resolve_mps_info(&path_str).context("Unknown MPS file type")?;
+        
+
+        let schema_bytes = reader.read_file(schema_path)?;
+        
+        let global_data = reader.global_data().unwrap_or_else(|_| Arc::new(BrdbSchemaGlobalData::default()));
+        let mut schema_cursor = schema_bytes.as_slice();
+        let schema = schema_cursor.read_brdb_schema_with_data(global_data.clone())?;
+
+
+        let val = cursor.read_brdb(&schema, type_name)?;
+        
+        let json_val = value_to_json(&val, &schema, &global_data)?;
+        let mut json_path = output_path.to_path_buf();
+        json_path.set_extension("mps.json");
+        let file = std::fs::File::create(json_path)?;
+        serde_json::to_writer_pretty(file, &json_val)?;
+    }
+
+    Ok(())
+}
+
+fn resolve_mps_info(path: &str) -> Option<(&'static str, &'static str)> {
+    if path.contains("GlobalData.mps") {
+        return Some(("World/0/GlobalData.schema", schemas::GLOBAL_DATA_SOA));
+    }
+    if path.contains("Owners.mps") {
+        return Some(("World/0/Owners.schema", schemas::OWNER_TABLE_SOA));
+    }
+    if path.contains("Bricks/Grids/") && path.contains("ChunkIndex.mps") {
+        return Some(("World/0/Bricks/ChunkIndexShared.schema", schemas::BRICK_CHUNK_INDEX_SOA));
+    }
+    if path.contains("Bricks/Grids/") && path.contains("/Chunks/") {
+        return Some(("World/0/Bricks/ChunksShared.schema", schemas::BRICK_CHUNK_SOA));
+    }
+    if path.contains("Bricks/Grids/") && path.contains("/Components/") {
+        return Some(("World/0/Bricks/ComponentsShared.schema", schemas::BRICK_COMPONENT_SOA));
+    }
+    if path.contains("Bricks/Grids/") && path.contains("/Wires/") {
+        return Some(("World/0/Bricks/WiresShared.schema", schemas::BRICK_WIRE_SOA));
+    }
+    if path.contains("Entities/ChunkIndex.mps") {
+        return Some(("World/0/Entities/ChunkIndex.schema", schemas::ENTITY_CHUNK_INDEX_SOA));
+    }
+    if path.contains("Entities/Chunks/") {
+        return Some(("World/0/Entities/ChunksShared.schema", schemas::ENTITY_CHUNK_SOA));
+    }
+    None
+}
+
+fn schema_to_json(schema: &BrdbSchema) -> Value {
+    let mut enums = serde_json::Map::new();
+    for (name, vals) in &schema.enums {
+        let name_str = schema.intern.lookup(*name).unwrap_or("?".to_string());
+        let mut variants = serde_json::Map::new();
+        for (k, v) in vals {
+             let k_str = schema.intern.lookup(*k).unwrap_or("?".to_string());
+             variants.insert(k_str, json!(v));
+        }
+        enums.insert(name_str, Value::Object(variants));
+    }
+
+    let mut structs = serde_json::Map::new();
+    for (name, props) in &schema.structs {
+        let name_str = schema.intern.lookup(*name).unwrap_or("?".to_string());
+        let mut prop_map = serde_json::Map::new();
+        for (k, v) in props {
+            let k_str = schema.intern.lookup(*k).unwrap_or("?".to_string());
+            prop_map.insert(k_str, json!(v.as_string(schema)));
+        }
+        structs.insert(name_str, Value::Object(prop_map));
+    }
+
+    json!({
+        "enums": enums,
+        "structs": structs
+    })
+}
+
+fn value_to_json(val: &BrdbValue, schema: &BrdbSchema, global_data: &BrdbSchemaGlobalData) -> Result<Value> {
+    Ok(match val {
+        BrdbValue::Nil => Value::Null,
+        BrdbValue::Bool(b) => json!(b),
+        BrdbValue::U8(n) => json!(n),
+        BrdbValue::U16(n) => json!(n),
+        BrdbValue::U32(n) => json!(n),
+        BrdbValue::U64(n) => json!(n),
+        BrdbValue::I8(n) => json!(n),
+        BrdbValue::I16(n) => json!(n),
+        BrdbValue::I32(n) => json!(n),
+        BrdbValue::I64(n) => json!(n),
+        BrdbValue::F32(n) => json!(n),
+        BrdbValue::F64(n) => json!(n),
+        BrdbValue::String(s) => json!(s),
+        BrdbValue::Asset(opt_idx) => {
+             if let Some(idx) = opt_idx {
+                 if let Some((ty, name)) = global_data.external_asset_references.get_index(*idx) {
+                     json!(format!("{}/{}", ty, name))
+                 } else {
+                     json!(format!("AssetIndex({})", idx))
+                 }
+             } else {
+                 Value::Null
+             }
+        },
+        BrdbValue::Enum(e) => {
+             json!(e.get_value())
+        },
+        BrdbValue::Struct(s) => {
+            let mut map = serde_json::Map::new();
+            for (k, v) in &s.properties {
+                let key_str = schema.intern.lookup(*k).unwrap_or("?".to_string());
+                map.insert(key_str, value_to_json(v, schema, global_data)?);
+            }
+            Value::Object(map)
+        },
+        BrdbValue::Array(arr) | BrdbValue::FlatArray(arr) => {
+            let mut vec = Vec::new();
+            for v in arr {
+                vec.push(value_to_json(v, schema, global_data)?);
+            }
+            Value::Array(vec)
+        },
+        BrdbValue::Map(m) => {
+
+             let mut map = serde_json::Map::new();
+             for (k, v) in m {
+                 let k_json = value_to_json(k, schema, global_data)?;
+                 let k_str = match k_json {
+                     Value::String(s) => s,
+                     _ => k_json.to_string(),
+                 };
+                 map.insert(k_str, value_to_json(v, schema, global_data)?);
+             }
+             Value::Object(map)
+        },
+        BrdbValue::WireVar(w) => json!(w.to_string()),
+    })
+}


### PR DESCRIPTION
add CLI tool that makes understanding worlds/prefabs easier. can convert `.schema` and `.mps` into json

Example json of a single microbrick
```json
{
  "BrickSizeCounters": [
    {
      "AssetIndex": 0,
      "NumSizes": 1
    }
  ],
  "BrickSizes": [
    {
      "X": 5,
      "Y": 5,
      "Z": 5
    }
  ],
  "BrickTypeIndices": [
    0
  ],
  "CollisionFlags_Interaction": {
    "Flags": [
      1
    ]
  },
  "CollisionFlags_Physics": {
    "Flags": [
      1
    ]
  },
  "CollisionFlags_Player": {
    "Flags": [
      1
    ]
  },
  "CollisionFlags_Player1": {
    "Flags": [
      1
    ]
  },
  "CollisionFlags_Player2": {
    "Flags": [
      1
    ]
  },
  "CollisionFlags_Player3": {
    "Flags": [
      1
    ]
  },
  "CollisionFlags_Tool": {
    "Flags": [
      1
    ]
  },
  "CollisionFlags_Weapon": {
    "Flags": [
      1
    ]
  },
  "ColorsAndAlphas": [
    {
      "A": 5,
      "B": 255,
      "G": 255,
      "R": 255
    }
  ],
  "MaterialIndices": [
    0
  ],
  "Orientations": [
    16
  ],
  "OwnerIndices": [
    0
  ],
  "ProceduralBrickStartingIndex": 0,
  "RelativePositions": [
    {
      "X": 859,
      "Y": 899,
      "Z": -1019
    }
  ],
  "VisibilityFlags": {
    "Flags": [
      1
    ]
  }
}
```